### PR TITLE
#35 - Implementar pesquisa básica na tela de listagem de pokémons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* [#35](https://github.com/afmireski/garchop-frontend/issues/35) - Implementar pesquisa básica na tela de listagem de pokémons
 * [#25](https://github.com/afmireski/garchop-frontend/issues/25) - Criar tela de carrinho
 
 ### Changed

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -26,6 +26,7 @@ export type PokemonData = {
 
 function Home() {
 
+    const [allPokemon, setAllPokemon] = useState<PokemonData[]>([]);
     const [pokemonArray, setPokemonArray] = useState<PokemonData[]>([]);
     let data;
     useEffect(() => {
@@ -36,6 +37,7 @@ function Home() {
                     ...pokemon,
                     slug: slugify(pokemon.name),
                 }));
+                setAllPokemon(newArrayCopy);
                 setPokemonArray(newArrayCopy);
             } catch (error) {
                 console.log(error);
@@ -47,7 +49,8 @@ function Home() {
     }, []); 
 
     const handleSearch = (text: string) => {
-        console.log(text);
+        const slugifiedText = slugify(text);
+        setPokemonArray(text ? allPokemon.filter((i) => i.slug.includes(slugifiedText)) : allPokemon);
     }
   return (
       <div>

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -25,8 +25,8 @@ export type PokemonData = {
 
 function Home() {
 
-    const [allPokemon, setAllPokemon] = useState<PokemonData[]>([]);
-    const [pokemonArray, setPokemonArray] = useState<PokemonData[]>([]);
+    const [pokemons, setPokemons] = useState<PokemonData[]>([]);
+    const [pokemonsToDisplay, setPokemonsToDisplay] = useState<PokemonData[]>([]);
     let data;
     useEffect(() => {
         async function getdados() {
@@ -36,8 +36,8 @@ function Home() {
                     ...pokemon,
                     slug: slugify(pokemon.name),
                 }));
-                setAllPokemon(newArrayCopy);
-                setPokemonArray(newArrayCopy);
+                setPokemons(newArrayCopy);
+                setPokemonsToDisplay(newArrayCopy);
             } catch (error) {
                 console.log(error);
                 throw new Error;
@@ -49,7 +49,7 @@ function Home() {
 
     const handleSearch = (text: string) => {
         const slugifiedText = slugify(text);
-        setPokemonArray(text ? allPokemon.filter((i) => i.slug.includes(slugifiedText)) : allPokemon);
+        setPokemonsToDisplay(text ? pokemons.filter((i) => i.slug.includes(slugifiedText)) : pokemons);
     }
   return (
       <div>
@@ -67,7 +67,7 @@ function Home() {
                 </div>
             </form>
           <div className="flex flex-row justify-center min-h-screen items-center gap-4 p-8 flex-wrap overflow-hidden">
-            {pokemonArray.map((pokeObj, index) => (
+            {pokemonsToDisplay.map((pokeObj, index) => (
                     <div key={index} className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
                         <Link href={`/pokemon/${pokeObj.id}`}>
                             <div className="md:flex">

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -20,6 +20,7 @@ export type PokemonData = {
     image_url: string;
     price: number;
     types: type[];
+    slug: string;
 }
 
 function Home() {
@@ -30,7 +31,10 @@ function Home() {
         async function getdados() {
             try {
                 data =  await GetAllPokemon();
-                const newArrayCopy: PokemonData[] = [...data];
+                const newArrayCopy: PokemonData[] = data.map((pokemon) => ({
+                    ...pokemon,
+                    slug: slugify(pokemon.name),
+                }));
                 setPokemonArray(newArrayCopy);
                 console.log(data)
             } catch {

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -65,17 +65,17 @@ function Home() {
                 </div>
             </form>
           <div className="flex flex-row justify-center min-h-screen items-center gap-4 p-8 flex-wrap overflow-hidden">
-            {pokemonArray.map((pokeObj) => (
-                    <div className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
+            {pokemonArray.map((pokeObj, index) => (
+                    <div key={index} className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
                         <Link href={`/pokemon/${pokeObj.id}`}>
                             <div className="md:flex">
                                 <div className="md:flex-shrink-0">
-                                <Link href={`/pokemon/${pokeObj.id}`}><img className="h-48 w-full object-cover md:w-48" src={pokeObj.image_url} alt="Imagem do Card" /></Link>
+                                <img className="h-48 w-full object-cover md:w-48" src={pokeObj.image_url} alt="Imagem do Card" />
                                 </div>
                                 <div className="p-8">
                                     <div className="uppercase tracking-wide text-sm text-indigo-500 font-semibold">{pokeObj.name}</div>
-                                    <div className="mt-2 text-blue-500"> {pokeObj.types.map((tPok) => (
-                                        <p>{tPok.name}</p>
+                                    <div className="mt-2 text-blue-500"> {pokeObj.types.map((tPok, index) => (
+                                        <p key={index}>{tPok.name}</p>
                                     ))}</div>
                                     <p className="mt-2 text-gray-500"> Price: P${pokeObj.price}</p>
                                 </div>

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -43,7 +43,7 @@ function Home() {
   return (
       <div>
           <Navbar />
-          <form className="max-w-lg mx-auto m-3">
+            <form className="max-w-lg mx-auto m-3">
                 <label htmlFor="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">Search</label>
                 <div className="relative">
                     <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -47,18 +47,18 @@ function Home() {
             {pokemonArray.map((pokeObj) => (
                     <div className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
                         <Link href={`/pokemon/${pokeObj.id}`}>
-                        <div className="md:flex">
-                            <div className="md:flex-shrink-0">
-                            <Link href={`/pokemon/${pokeObj.id}`}><img className="h-48 w-full object-cover md:w-48" src={pokeObj.image_url} alt="Imagem do Card" /></Link>
+                            <div className="md:flex">
+                                <div className="md:flex-shrink-0">
+                                <Link href={`/pokemon/${pokeObj.id}`}><img className="h-48 w-full object-cover md:w-48" src={pokeObj.image_url} alt="Imagem do Card" /></Link>
+                                </div>
+                                <div className="p-8">
+                                    <div className="uppercase tracking-wide text-sm text-indigo-500 font-semibold">{pokeObj.name}</div>
+                                    <div className="mt-2 text-blue-500"> {pokeObj.types.map((tPok) => (
+                                        <p>{tPok.name}</p>
+                                    ))}</div>
+                                    <p className="mt-2 text-gray-500"> Price: P${pokeObj.price}</p>
+                                </div>
                             </div>
-                            <div className="p-8">
-                                <div className="uppercase tracking-wide text-sm text-indigo-500 font-semibold">{pokeObj.name}</div>
-                                <div className="mt-2 text-blue-500"> {pokeObj.types.map((tPok) => (
-                                    <p>{tPok.name}</p>
-                                ))}</div>
-                                <p className="mt-2 text-gray-500"> Price: P${pokeObj.price}</p>
-                            </div>
-                        </div>
                         </Link>
                     </div>
                 ))}

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -37,9 +37,9 @@ function Home() {
                     slug: slugify(pokemon.name),
                 }));
                 setPokemonArray(newArrayCopy);
-                console.log(data)
-            } catch {
-                console.log('erro')
+            } catch (error) {
+                console.log(error);
+                throw new Error;
             }
         }
 

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -40,6 +40,10 @@ function Home() {
 
         getdados();
     }, []); 
+
+    const handleSearch = (text: string) => {
+        console.log(text);
+    }
   return (
       <div>
           <Navbar />
@@ -51,7 +55,7 @@ function Home() {
                             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                         </svg>
                     </div>
-                    <input type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />
+                    <input onChange={(e) => handleSearch(e.target.value)} type="search" id="default-earch" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />
                     <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Buscar</button>
                 </div>
             </form>

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -46,18 +46,20 @@ function Home() {
           <div className="flex flex-row justify-center min-h-screen items-center gap-4 p-8 flex-wrap overflow-hidden">
             {pokemonArray.map((pokeObj) => (
                     <div className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
+                        <Link href={`/pokemon/${pokeObj.id}`}>
                         <div className="md:flex">
                             <div className="md:flex-shrink-0">
                             <Link href={`/pokemon/${pokeObj.id}`}><img className="h-48 w-full object-cover md:w-48" src={pokeObj.image_url} alt="Imagem do Card" /></Link>
                             </div>
                             <div className="p-8">
-                                <div className="uppercase tracking-wide text-sm text-indigo-500 font-semibold"><Link href={`/pokemon/${pokeObj.id}`}>{pokeObj.name}</Link></div>
+                                <div className="uppercase tracking-wide text-sm text-indigo-500 font-semibold">{pokeObj.name}</div>
                                 <div className="mt-2 text-blue-500"> {pokeObj.types.map((tPok) => (
                                     <p>{tPok.name}</p>
                                 ))}</div>
                                 <p className="mt-2 text-gray-500"> Price: P${pokeObj.price}</p>
                             </div>
                         </div>
+                        </Link>
                     </div>
                 ))}
           </div>

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -43,6 +43,18 @@ function Home() {
   return (
       <div>
           <Navbar />
+          <form className="max-w-lg mx-auto m-3">
+                <label htmlFor="default-search" className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">Search</label>
+                <div className="relative">
+                    <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                        <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                        </svg>
+                    </div>
+                    <input type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />
+                    <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Buscar</button>
+                </div>
+            </form>
           <div className="flex flex-row justify-center min-h-screen items-center gap-4 p-8 flex-wrap overflow-hidden">
             {pokemonArray.map((pokeObj) => (
                     <div className="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -5,6 +5,7 @@ import "@/app/globals.css";
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import GetAllPokemon from '@/APIs/getAllPokemon';
+import slugify from '@/utils/string';
 import { type } from 'os';
 
 export type type = {

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -57,7 +57,7 @@ function Home() {
                 <div className="relative">
                     <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                         <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                         </svg>
                     </div>
                     <input onChange={(e) => handleSearch(e.target.value)} type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -6,7 +6,6 @@ import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import GetAllPokemon from '@/APIs/getAllPokemon';
 import slugify from '@/utils/string';
-import { type } from 'os';
 
 export type type = {
     id: string;

--- a/magmartfront/src/app/home/page.tsx
+++ b/magmartfront/src/app/home/page.tsx
@@ -55,7 +55,7 @@ function Home() {
                             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                         </svg>
                     </div>
-                    <input onChange={(e) => handleSearch(e.target.value)} type="search" id="default-earch" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />
+                    <input onChange={(e) => handleSearch(e.target.value)} type="search" id="default-search" className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar Pokémon..." required />
                     <button type="submit" className="text-white absolute end-2.5 bottom-2.5 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Buscar</button>
                 </div>
             </form>

--- a/magmartfront/src/utils/string.ts
+++ b/magmartfront/src/utils/string.ts
@@ -1,0 +1,13 @@
+/**
+ * Source: https://byby.dev/js-slugify-string
+ */
+export default function slugify(text: String) {
+        return text
+                .normalize("NFKD")
+                .replace(/[\u0300-\u036f]/g, "")
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9 -]/g, "")
+                .replace(/\s+/g, "-")
+                .replace(/-+/g, "-");
+}


### PR DESCRIPTION
## Descrição
Nessa issue foi criado um campo de busca de pokémons na tela inicial (``/home`` ), assim, os clientes são capazes de realizar buscas por um filtro. Além disso, foi alterado para que os cards dos pokémons se tornem inteiramente clicáveis.

**OBS**: Um dos requisitos era realizar a busca na API utilizando parâmetros de url, no entanto, o requisito não foi cumprido porque a busca poderia ser feita sem precisar requisitar para a API.


## Contexto
- **motivação:** adicionar um campo de busca; realizar alterações para melhorar usabilidade dos clientes;.

closes #35 

## Como testar

### Escritor
- [X] O campo de busca está funcionando:
	- [X] Se o campo de busca está vazio, todos os pokémons são listados.
	- [X] Se o campo de busca não está vazio, a listagem de pokémons corresponde ao texto da pesquisa.
	
### Tester
- [x] O campo de busca está funcionando:
	- [x] Se o campo de busca está vazio, todos os pokémons são listados.
	- [x] Se o campo de busca não está vazio, a listagem de pokémons corresponde ao texto da pesquisa.

## Natureza da alteração
- [X] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.